### PR TITLE
canvas insertion and event registration

### DIFF
--- a/services/canvas/src/components/Drawing.tsx
+++ b/services/canvas/src/components/Drawing.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
@@ -22,10 +22,91 @@ interface Sketch {
   imageUrl: string;
 }
 
+interface Coordinate {
+  x: number;
+  y: number;
+}
+
+interface DrawingProps {
+  id: number;
+  width: number;
+  height: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-function Drawing({ id }: { id: number }): JSX.Element {
+function Drawing({ id, width, height }: DrawingProps): JSX.Element {
   const classes = useStyles();
   const [imgUrl, setImgUrl] = useState('');
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const [mousePosition, setMousePosition] = useState<Coordinate | undefined>(
+    undefined
+  );
+  const [isPainting, setIsPainting] = useState(false);
+
+  const getCoordinates = (event: MouseEvent): Coordinate | undefined => {
+    if (!canvasRef.current) {
+      return;
+    }
+
+    const canvas: HTMLCanvasElement = canvasRef.current;
+    return {
+      x: event.pageX - canvas.offsetLeft,
+      y: event.pageY - canvas.offsetTop
+    };
+  };
+
+  const drawLine = (
+    originalMousePosition: Coordinate,
+    newMousePosition: Coordinate
+  ) => {
+    if (!canvasRef.current) {
+      return;
+    }
+    const canvas: HTMLCanvasElement = canvasRef.current;
+    const context = canvas.getContext('2d');
+
+    if (context) {
+      context.strokeStyle = 'red';
+      context.lineJoin = 'round';
+      context.lineWidth = 5;
+
+      context.beginPath();
+      context.moveTo(originalMousePosition.x, originalMousePosition.y);
+      context.lineTo(newMousePosition.x, newMousePosition.y);
+      context.closePath();
+
+      context.stroke();
+    }
+  };
+
+  const startPaint = useCallback((event: MouseEvent) => {
+    const coordinates = getCoordinates(event);
+    if (coordinates) {
+      setIsPainting(true);
+      setMousePosition(coordinates);
+    }
+  }, []);
+
+  const paint = useCallback(
+    (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (isPainting) {
+        const newMousePosition = getCoordinates(event);
+        if (mousePosition && newMousePosition) {
+          drawLine(mousePosition, newMousePosition);
+          setMousePosition(newMousePosition);
+        }
+      }
+    },
+    [isPainting, mousePosition]
+  );
+
+  const exitPaint = useCallback(() => {
+    setIsPainting(false);
+  }, []);
 
   useEffect(() => {
     getSketch(id).then((sketch: Sketch) => {
@@ -34,6 +115,25 @@ function Drawing({ id }: { id: number }): JSX.Element {
       }
     });
   }, [id, setImgUrl]);
+
+  useEffect(() => {
+    if (!canvasRef.current) {
+      return;
+    }
+    const canvas: HTMLCanvasElement = canvasRef.current;
+
+    canvas.addEventListener('mousedown', startPaint);
+    canvas.addEventListener('mousemove', paint);
+    canvas.addEventListener('mouseup', exitPaint);
+    canvas.addEventListener('mouseleave', exitPaint);
+
+    return () => {
+      canvas.removeEventListener('mousedown', startPaint);
+      canvas.removeEventListener('mousemove', paint);
+      canvas.removeEventListener('mouseup', exitPaint);
+      canvas.removeEventListener('mouseleave', exitPaint);
+    };
+  }, [startPaint, paint, exitPaint]);
   return (
     <div className={classes.root}>
       <Grid container spacing={10}>
@@ -42,8 +142,13 @@ function Drawing({ id }: { id: number }): JSX.Element {
         </Grid>
         <Grid item xs={12}>
           <Paper className={classes.paper}>
-            Image
-            <img width={450} src={`${BASE_URL}/${imgUrl}`} alt="tile" />
+            <canvas
+              ref={canvasRef}
+              className="canvas"
+              height={height}
+              width={width}
+              style={{ backgroundImage: `url(${BASE_URL}/${imgUrl})` }}
+            />
           </Paper>
         </Grid>
         <Grid item xs={12}>
@@ -53,5 +158,10 @@ function Drawing({ id }: { id: number }): JSX.Element {
     </div>
   );
 }
+
+Drawing.defaultProps = {
+  width: 800,
+  height: 600
+};
 
 export default Drawing;


### PR DESCRIPTION
- [x] canvas tag 삽입 및 이벤트 등록 ->  요청 이미지를 canvas의 background image로 설정해서 drawing을 하면 원본을 가리게 됨(추후 css적인 요소를 사용하여(position: absolute와같은? ) 이미지와 같은 크기로 canvas를 겹쳐야 할 것으로 생각됨. 